### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ else
 end
 ```
 
-Its also possible to pass arbitary arguments to `feature_active?` like so:
+Its also possible to pass arbitrary arguments to `feature_active?` like so:
   
 ```ruby
 if feature_active?(:hidden_feature, "secret_sauce")


### PR DESCRIPTION
@blaulabs, I've corrected a typographical error in the documentation of the [ruby_flipper](https://github.com/blaulabs/ruby_flipper) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
